### PR TITLE
Introduce default pricing endpoint

### DIFF
--- a/slpricing.py
+++ b/slpricing.py
@@ -1,11 +1,15 @@
 import boto3
 import json
+import os
 
 priceList = []
 #retrieve price list
 def getPriceList():
     global priceList
-    pricing = boto3.client('pricing')
+    pricing_client_region = 'us-east-1' # price list service API provides two endpoints: us-east-1 and ap-south-1
+    if os.getenv("AWS_DEFAULT_REGION") == 'ap-south-1':
+        pricing_client_region = 'ap-south-1'
+    pricing = boto3.client('pricing', region_name=pricing_client_region)
     response = pricing.get_products( ServiceCode='AmazonSecurityLake')
     priceList = response['PriceList']
     while "NextToken" in response:


### PR DESCRIPTION
*Description of changes:*

When running locally from any other region than `us-east-1` or `ap-south-1`, the boto3 pricing calls fail with e.g.

```text
botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL: "https://api.pricing.eu-central-1.amazonaws.com/"
```

The service endpoint AWS Price List service API provides the following two endpoints:

- https://api.pricing.us-east-1.amazonaws.com
- https://api.pricing.ap-south-1.amazonaws.com

With this PR the `us-east-1` is used as a default endpoint; if run with region `ap-south-1`, then  `api.pricing.ap-south-1.amazonaws.com` is used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
